### PR TITLE
Added Player and Profile model classes

### DIFF
--- a/Griffig/Assets/Scripts.meta
+++ b/Griffig/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5fae87d81ff49ba419d4a99735dfc461
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Griffig/Assets/Scripts/Models.meta
+++ b/Griffig/Assets/Scripts/Models.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ebcef85f6e817c64dbefb9d59494f3ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Griffig/Assets/Scripts/Models/Player.cs
+++ b/Griffig/Assets/Scripts/Models/Player.cs
@@ -15,7 +15,8 @@ public class Player
   /// <summary>
   /// Indicates if this is the player of this device.
   /// </summary>
-  public bool IsLocal { get; }
+  public bool IsLocal => throw new NotImplementedException();
+  private Guid _profileID;
 
   /// <summary>
   /// Current score of the player.
@@ -27,24 +28,15 @@ public class Player
   #region Construction
 
   /// <summary>
-  /// Constructor for creating a player from a <see cref="Profile"/>.
-  /// </summary>
-  /// <param name="profile">Profile belonging to this player.</param>
-  /// <exception cref="ArgumentNullException">If <paramref name="profile"/> is null.</exception>
-  internal Player(Profile profile)
-    : this(profile?.Name)
-  {
-    IsLocal = true;
-  }
-
-  /// <summary>
   /// Constructor.
   /// </summary>
   /// <param name="name">Name of the player.</param>
+  /// <param name="profileID">Profile ID of the profile this player belongs to.</param>
   /// <exception cref="ArgumentNullException">If <paramref name="name"/> is null.</exception>
-  public Player(string name)
+  public Player(string name, Guid profileID)
   {
     Name = name ?? throw new ArgumentNullException(nameof(name));
+    _profileID = profileID;
   }
 
   #endregion Construction

--- a/Griffig/Assets/Scripts/Models/Player.cs
+++ b/Griffig/Assets/Scripts/Models/Player.cs
@@ -1,0 +1,51 @@
+using System;
+
+/// <summary>
+/// Player participating in a game.
+/// </summary>
+public class Player
+{
+  #region Properties
+
+  /// <summary>
+  /// Name of the player.
+  /// </summary>
+  public string Name { get; }
+
+  /// <summary>
+  /// Indicates if this is the player of this device.
+  /// </summary>
+  public bool IsLocal { get; }
+
+  /// <summary>
+  /// Current score of the player.
+  /// </summary>
+  public int Score { get; set; }
+
+  #endregion Properties
+
+  #region Construction
+
+  /// <summary>
+  /// Constructor for creating a player from a <see cref="Profile"/>.
+  /// </summary>
+  /// <param name="profile">Profile belonging to this player.</param>
+  /// <exception cref="ArgumentNullException">If <paramref name="profile"/> is null.</exception>
+  internal Player(Profile profile)
+    : this(profile?.Name)
+  {
+    IsLocal = true;
+  }
+
+  /// <summary>
+  /// Constructor.
+  /// </summary>
+  /// <param name="name">Name of the player.</param>
+  /// <exception cref="ArgumentNullException">If <paramref name="name"/> is null.</exception>
+  public Player(string name)
+  {
+    Name = name ?? throw new ArgumentNullException(nameof(name));
+  }
+
+  #endregion Construction
+}

--- a/Griffig/Assets/Scripts/Models/Player.cs.meta
+++ b/Griffig/Assets/Scripts/Models/Player.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 29f1971d62f7ce845b7503f37aef8e37

--- a/Griffig/Assets/Scripts/Models/Profile.cs
+++ b/Griffig/Assets/Scripts/Models/Profile.cs
@@ -1,0 +1,16 @@
+﻿/// <summary>
+/// Profile of a <see cref="Player"/>.
+/// This represents more like an "account" and not a
+/// game participant.
+/// </summary>
+internal class Profile
+{
+  #region Properties
+
+  /// <summary>
+  /// Name of the profile.
+  /// </summary>
+  public string Name { get; set; }
+
+  #endregion Properties
+}

--- a/Griffig/Assets/Scripts/Models/Profile.cs
+++ b/Griffig/Assets/Scripts/Models/Profile.cs
@@ -1,4 +1,6 @@
-﻿/// <summary>
+﻿using System;
+
+/// <summary>
 /// Profile of a <see cref="Player"/>.
 /// This represents more like an "account" and not a
 /// game participant.
@@ -11,6 +13,11 @@ internal class Profile
   /// Name of the profile.
   /// </summary>
   public string Name { get; set; }
+
+  /// <summary>
+  /// 'Unique' profile id.
+  /// </summary>
+  private Guid _id;
 
   #endregion Properties
 }

--- a/Griffig/Assets/Scripts/Models/Profile.cs.meta
+++ b/Griffig/Assets/Scripts/Models/Profile.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3a8ea9b74926ffd43a9c0ffbd7535c63


### PR DESCRIPTION
Very basic model classes for a Profile (account) and a Player (ingame)
The distinction is very basic at the moment but will be useful later if we want to add more info to a profile.
Profile contains data that will not be transmitted to the server (statistics for example)